### PR TITLE
优化错误处理

### DIFF
--- a/ekafka/README.md
+++ b/ekafka/README.md
@@ -14,6 +14,8 @@
 
 ## Consumer Server 组件
 
+> 必须配置 ConsumerGroup 使用。
+
 基本组件通常是搭配其他服务模块（如 [HTTP 服务](https://ego.gocn.vip/frame/server/http.html)）一起使用的，如果只想使用 Ego 做单纯的 Kafka 消费应用，可以使用 [Consumer Server 组件](consumerserver/)。
 
 Consumer Server 组件依赖于基本组件提供 Kafka 消费者实例，同时实现了 `ego.Server` 接口以达到常驻运行的目的，并且和 Ego 框架共享生命周期。

--- a/ekafka/container.go
+++ b/ekafka/container.go
@@ -90,6 +90,7 @@ func (c *Container) Build(options ...Option) *Component {
 	// 初始化consumers
 	cmp.consumers = make(map[string]*Consumer)
 	l := &logger{cmp.logger}
+	el := &errorLogger{cmp.logger}
 	for name, cg := range c.config.Consumers {
 		r := &Consumer{
 			r: kafka.NewReader(kafka.ReaderConfig{
@@ -104,7 +105,8 @@ func (c *Container) Build(options ...Option) *Component {
 				RebalanceTimeout:       cg.RebalanceTimeout,
 				MaxWait:                cg.MaxWait,
 				ReadLagInterval:        cg.ReadLagInterval,
-				ErrorLogger:            l,
+				Logger:                 l,
+				ErrorLogger:            el,
 				HeartbeatInterval:      cg.HeartbeatInterval,
 				CommitInterval:         cg.CommitInterval,
 				SessionTimeout:         cg.SessionTimeout,
@@ -129,5 +131,13 @@ type logger struct {
 }
 
 func (l *logger) Printf(tmpl string, args ...interface{}) {
+	l.Debugf(tmpl, args...)
+}
+
+type errorLogger struct {
+	*elog.Component
+}
+
+func (l *errorLogger) Printf(tmpl string, args ...interface{}) {
 	l.Errorf(tmpl, args...)
 }


### PR DESCRIPTION
改动：

- ekafka 中初始化 `Reader` 时配置 [`Logger`](https://github.com/segmentio/kafka-go/blob/130499d2d62d8befc5565cf3f54aeb249d639f45/consumergroup.go#L144)，输出 debug 级别日志用来排查问题
- 优化 ConsumerGroup#OnEachMessage 的错误处理
  - 当 handler 返回错误时视为不可恢复异常，直接退出（开发者应该在 handler 内部自己实现重试逻辑）
  - Commit message 失败时进行重试