### PR TITLE
ego/ekafka: 把 consumer、producer 改为懒加载

### DIFF
--- a/ekafka/component.go
+++ b/ekafka/component.go
@@ -17,9 +17,9 @@ type Component struct {
 	client     *Client
 	consumers  map[string]*Consumer
 	producers  map[string]*Producer
-	clientMu   sync.Mutex
-	consumerMu sync.Mutex
-	producerMu sync.Mutex
+	clientOnce sync.Once
+	consumerMu sync.RWMutex
+	producerMu sync.RWMutex
 }
 
 func (cmp *Component) interceptorChain() func(oldProcess processFn) processFn {
@@ -28,125 +28,132 @@ func (cmp *Component) interceptorChain() func(oldProcess processFn) processFn {
 
 // Producer 返回指定名称的kafka Producer
 func (cmp *Component) Producer(name string) *Producer {
+	cmp.producerMu.RLock()
+
 	if producer, ok := cmp.producers[name]; ok {
+		cmp.producerMu.RUnlock()
 		return producer
 	}
 
+	cmp.producerMu.RUnlock()
 	cmp.producerMu.Lock()
-	defer cmp.producerMu.Unlock()
 
-	if _, ok := cmp.producers[name]; !ok {
-		config, ok := cmp.config.Producers[name]
-		if !ok {
-			cmp.logger.Panic("producer config not exists", elog.String("name", name))
-		}
-
-		// 如果未设置balancer，则使用roundRobin
-		if config.Balancer == "" {
-			config.Balancer = balancerRoundRobin
-		}
-		balancer, ok := cmp.config.balancers[config.Balancer]
-		if !ok {
-			panic(fmt.Sprintf(
-				"producer.Balancer is not in registered balancers, %s, %v",
-				config.Balancer,
-				cmp.config.balancers,
-			))
-		}
-		producer := &Producer{
-			w: &kafka.Writer{
-				Addr:         kafka.TCP(cmp.config.Brokers...),
-				Topic:        config.Topic,
-				Balancer:     balancer,
-				MaxAttempts:  config.MaxAttempts,
-				BatchSize:    config.BatchSize,
-				BatchBytes:   config.BatchBytes,
-				BatchTimeout: config.BatchTimeout,
-				ReadTimeout:  config.ReadTimeout,
-				WriteTimeout: config.WriteTimeout,
-				RequiredAcks: config.RequiredAcks,
-				Async:        config.Async,
-			},
-			processor: defaultProcessor,
-			logMode:   cmp.config.Debug,
-		}
-		producer.wrapProcessor(cmp.interceptorChain())
-
-		cmp.producers[name] = producer
+	if producer, ok := cmp.producers[name]; ok {
+		cmp.producerMu.Unlock()
+		return producer
 	}
+
+	config, ok := cmp.config.Producers[name]
+	if !ok {
+		cmp.logger.Panic("producer config not exists", elog.String("name", name))
+	}
+	// 如果未设置balancer，则使用roundRobin
+	if config.Balancer == "" {
+		config.Balancer = balancerRoundRobin
+	}
+	balancer, ok := cmp.config.balancers[config.Balancer]
+	if !ok {
+		cmp.producerMu.Unlock()
+		panic(fmt.Sprintf(
+			"producer.Balancer is not in registered balancers, %s, %v",
+			config.Balancer,
+			cmp.config.balancers,
+		))
+	}
+	producer := &Producer{
+		w: &kafka.Writer{
+			Addr:         kafka.TCP(cmp.config.Brokers...),
+			Topic:        config.Topic,
+			Balancer:     balancer,
+			MaxAttempts:  config.MaxAttempts,
+			BatchSize:    config.BatchSize,
+			BatchBytes:   config.BatchBytes,
+			BatchTimeout: config.BatchTimeout,
+			ReadTimeout:  config.ReadTimeout,
+			WriteTimeout: config.WriteTimeout,
+			RequiredAcks: config.RequiredAcks,
+			Async:        config.Async,
+		},
+		processor: defaultProcessor,
+		logMode:   cmp.config.Debug,
+	}
+	producer.wrapProcessor(cmp.interceptorChain())
+	cmp.producers[name] = producer
+
+	cmp.producerMu.Unlock()
 
 	return cmp.producers[name]
 }
 
 // Consumer 返回指定名称的kafka Consumer
 func (cmp *Component) Consumer(name string) *Consumer {
+	cmp.consumerMu.RLock()
+
 	if consumer, ok := cmp.consumers[name]; ok {
+		cmp.consumerMu.RUnlock()
 		return consumer
 	}
 
+	cmp.consumerMu.RUnlock()
 	cmp.consumerMu.Lock()
-	defer cmp.consumerMu.Unlock()
 
-	if _, ok := cmp.consumers[name]; !ok {
-		config, ok := cmp.config.Consumers[name]
-		if !ok {
-			cmp.logger.Panic("consumer config not exists", elog.String("name", name))
-		}
-
-		logger := newKafkaLogger(cmp.logger)
-		errorLogger := newKafkaErrorLogger(cmp.logger)
-		consumer := &Consumer{
-			r: kafka.NewReader(kafka.ReaderConfig{
-				Brokers:                cmp.config.Brokers,
-				Topic:                  config.Topic,
-				GroupID:                config.GroupID,
-				Partition:              config.Partition,
-				MinBytes:               config.MinBytes,
-				MaxBytes:               config.MaxBytes,
-				WatchPartitionChanges:  config.WatchPartitionChanges,
-				PartitionWatchInterval: config.PartitionWatchInterval,
-				RebalanceTimeout:       config.RebalanceTimeout,
-				MaxWait:                config.MaxWait,
-				ReadLagInterval:        config.ReadLagInterval,
-				Logger:                 logger,
-				ErrorLogger:            errorLogger,
-				HeartbeatInterval:      config.HeartbeatInterval,
-				CommitInterval:         config.CommitInterval,
-				SessionTimeout:         config.SessionTimeout,
-				JoinGroupBackoff:       config.JoinGroupBackoff,
-				RetentionTime:          config.RetentionTime,
-				StartOffset:            config.StartOffset,
-				ReadBackoffMin:         config.ReadBackoffMin,
-				ReadBackoffMax:         config.ReadBackoffMax,
-			}),
-			processor: defaultProcessor,
-			logMode:   cmp.config.Debug,
-		}
-		consumer.wrapProcessor(cmp.interceptorChain())
-
-		cmp.consumers[name] = consumer
+	if consumer, ok := cmp.consumers[name]; ok {
+		cmp.consumerMu.Unlock()
+		return consumer
 	}
+
+	config, ok := cmp.config.Consumers[name]
+	if !ok {
+		cmp.consumerMu.Unlock()
+		cmp.logger.Panic("consumer config not exists", elog.String("name", name))
+	}
+	logger := newKafkaLogger(cmp.logger)
+	errorLogger := newKafkaErrorLogger(cmp.logger)
+	consumer := &Consumer{
+		r: kafka.NewReader(kafka.ReaderConfig{
+			Brokers:                cmp.config.Brokers,
+			Topic:                  config.Topic,
+			GroupID:                config.GroupID,
+			Partition:              config.Partition,
+			MinBytes:               config.MinBytes,
+			MaxBytes:               config.MaxBytes,
+			WatchPartitionChanges:  config.WatchPartitionChanges,
+			PartitionWatchInterval: config.PartitionWatchInterval,
+			RebalanceTimeout:       config.RebalanceTimeout,
+			MaxWait:                config.MaxWait,
+			ReadLagInterval:        config.ReadLagInterval,
+			Logger:                 logger,
+			ErrorLogger:            errorLogger,
+			HeartbeatInterval:      config.HeartbeatInterval,
+			CommitInterval:         config.CommitInterval,
+			SessionTimeout:         config.SessionTimeout,
+			JoinGroupBackoff:       config.JoinGroupBackoff,
+			RetentionTime:          config.RetentionTime,
+			StartOffset:            config.StartOffset,
+			ReadBackoffMin:         config.ReadBackoffMin,
+			ReadBackoffMax:         config.ReadBackoffMax,
+		}),
+		processor: defaultProcessor,
+		logMode:   cmp.config.Debug,
+	}
+	consumer.wrapProcessor(cmp.interceptorChain())
+	cmp.consumers[name] = consumer
+
+	cmp.consumerMu.Unlock()
 
 	return cmp.consumers[name]
 }
 
 // Client 返回kafka Client
 func (cmp *Component) Client() *Client {
-	if cmp.client != nil {
-		return cmp.client
-	}
-
-	cmp.clientMu.Lock()
-	defer cmp.clientMu.Unlock()
-
-	if cmp.client == nil {
+	cmp.clientOnce.Do(func() {
 		cmp.client = &Client{
 			cc:        &kafka.Client{Addr: kafka.TCP(cmp.config.Brokers...), Timeout: cmp.config.Client.Timeout},
 			processor: defaultProcessor,
 			logMode:   cmp.config.Debug,
 		}
 		cmp.client.wrapProcessor(cmp.interceptorChain())
-	}
+	})
 
 	return cmp.client
 }

--- a/ekafka/component.go
+++ b/ekafka/component.go
@@ -1,7 +1,11 @@
 package ekafka
 
 import (
+	"fmt"
+	"sync"
+
 	"github.com/gotomicro/ego/core/elog"
+	"github.com/segmentio/kafka-go"
 )
 
 const PackageName = "component.ekafka"
@@ -13,19 +17,122 @@ type Component struct {
 	client    *Client
 	consumers map[string]*Consumer
 	producers map[string]*Producer
+	mu        sync.Mutex
 }
 
-// Consumer 返回指定名称的kafka Consumer
-func (cmp Component) Consumer(name string) *Consumer {
-	return cmp.consumers[name]
+func (cmp *Component) interceptorChain() func(oldProcess processFn) processFn {
+	return InterceptorChain(cmp.config.interceptors...)
 }
 
-// Consumer 返回指定名称的kafka Producer
-func (cmp Component) Producer(name string) *Producer {
+// Producer 返回指定名称的kafka Producer
+func (cmp *Component) Producer(name string) *Producer {
+	cmp.mu.Lock()
+	defer cmp.mu.Unlock()
+
+	if _, ok := cmp.producers[name]; !ok {
+		config, ok := cmp.config.Producers[name]
+		if !ok {
+			cmp.logger.Panic("producer config not exists", elog.String("name", name))
+		}
+
+		// 如果未设置balancer，则使用roundRobin
+		if config.Balancer == "" {
+			config.Balancer = balancerRoundRobin
+		}
+		balancer, ok := cmp.config.balancers[config.Balancer]
+		if !ok {
+			panic(fmt.Sprintf(
+				"producer.Balancer is not in registered balancers, %s, %v",
+				config.Balancer,
+				cmp.config.balancers,
+			))
+		}
+		producer := &Producer{
+			w: &kafka.Writer{
+				Addr:         kafka.TCP(cmp.config.Brokers...),
+				Topic:        config.Topic,
+				Balancer:     balancer,
+				MaxAttempts:  config.MaxAttempts,
+				BatchSize:    config.BatchSize,
+				BatchBytes:   config.BatchBytes,
+				BatchTimeout: config.BatchTimeout,
+				ReadTimeout:  config.ReadTimeout,
+				WriteTimeout: config.WriteTimeout,
+				RequiredAcks: config.RequiredAcks,
+				Async:        config.Async,
+			},
+			processor: defaultProcessor,
+			logMode:   cmp.config.Debug,
+		}
+		producer.wrapProcessor(cmp.interceptorChain())
+
+		cmp.producers[name] = producer
+	}
+
 	return cmp.producers[name]
 }
 
+// Consumer 返回指定名称的kafka Consumer
+func (cmp *Component) Consumer(name string) *Consumer {
+	cmp.mu.Lock()
+	defer cmp.mu.Unlock()
+
+	if _, ok := cmp.consumers[name]; !ok {
+		config, ok := cmp.config.Consumers[name]
+		if !ok {
+			cmp.logger.Panic("consumer config not exists", elog.String("name", name))
+		}
+
+		logger := newKafkaLogger(cmp.logger)
+		errorLogger := newKafkaErrorLogger(cmp.logger)
+		consumer := &Consumer{
+			r: kafka.NewReader(kafka.ReaderConfig{
+				Brokers:                cmp.config.Brokers,
+				Topic:                  config.Topic,
+				GroupID:                config.GroupID,
+				Partition:              config.Partition,
+				MinBytes:               config.MinBytes,
+				MaxBytes:               config.MaxBytes,
+				WatchPartitionChanges:  config.WatchPartitionChanges,
+				PartitionWatchInterval: config.PartitionWatchInterval,
+				RebalanceTimeout:       config.RebalanceTimeout,
+				MaxWait:                config.MaxWait,
+				ReadLagInterval:        config.ReadLagInterval,
+				Logger:                 logger,
+				ErrorLogger:            errorLogger,
+				HeartbeatInterval:      config.HeartbeatInterval,
+				CommitInterval:         config.CommitInterval,
+				SessionTimeout:         config.SessionTimeout,
+				JoinGroupBackoff:       config.JoinGroupBackoff,
+				RetentionTime:          config.RetentionTime,
+				StartOffset:            config.StartOffset,
+				ReadBackoffMin:         config.ReadBackoffMin,
+				ReadBackoffMax:         config.ReadBackoffMax,
+			}),
+			processor: defaultProcessor,
+			logMode:   cmp.config.Debug,
+		}
+		consumer.wrapProcessor(cmp.interceptorChain())
+
+		cmp.consumers[name] = consumer
+	}
+
+	return cmp.consumers[name]
+}
+
 // Client 返回kafka Client
-func (cmp Component) Client() *Client {
+func (cmp *Component) Client() *Client {
+	cmp.mu.Lock()
+	defer cmp.mu.Unlock()
+
+	if cmp.client == nil {
+		cmp.client = &Client{
+			cc:        &kafka.Client{Addr: kafka.TCP(cmp.config.Brokers...), Timeout: cmp.config.Client.Timeout},
+			processor: defaultProcessor,
+			logMode:   cmp.config.Debug,
+		}
+		cmp.client.wrapProcessor(cmp.interceptorChain())
+	}
+
 	return cmp.client
 }

--- a/ekafka/container.go
+++ b/ekafka/container.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/gotomicro/ego/core/econf"
 	"github.com/gotomicro/ego/core/elog"
-	"github.com/segmentio/kafka-go"
 )
 
 type Option func(c *Container)
@@ -51,101 +50,11 @@ func (c *Container) Build(options ...Option) *Component {
 
 	c.logger = c.logger.With(elog.FieldAddr(fmt.Sprintf("%s", c.config.Brokers)))
 	cmp := &Component{
-		config: c.config,
-		logger: c.logger,
-	}
-	// 初始化client
-	cmp.client = &Client{
-		cc:        &kafka.Client{Addr: kafka.TCP(c.config.Brokers...), Timeout: c.config.Client.Timeout},
-		processor: defaultProcessor,
-		logMode:   c.config.Debug,
-	}
-	ic := InterceptorChain(c.config.interceptors...)
-	cmp.client.wrapProcessor(ic)
-
-	// 初始化producers
-	cmp.producers = make(map[string]*Producer)
-	for name, producer := range c.config.Producers {
-		// 如果未设置balancer，则使用roundRobin
-		if producer.Balancer == "" {
-			producer.Balancer = balancerRoundRobin
-		}
-		b, ok := c.config.balancers[producer.Balancer]
-		if !ok {
-			panic(fmt.Sprintf("producer.Balancer is not in registered balancers, %s, %v", producer.Balancer, c.config.balancers))
-		}
-		w := &Producer{
-			w: &kafka.Writer{
-				Addr:         kafka.TCP(c.config.Brokers...),
-				Topic:        producer.Topic,
-				Balancer:     b,
-				MaxAttempts:  producer.MaxAttempts,
-				BatchSize:    producer.BatchSize,
-				BatchBytes:   producer.BatchBytes,
-				BatchTimeout: producer.BatchTimeout,
-				ReadTimeout:  producer.ReadTimeout,
-				WriteTimeout: producer.WriteTimeout,
-				RequiredAcks: producer.RequiredAcks,
-				Async:        producer.Async,
-			},
-			processor: defaultProcessor,
-			logMode:   c.config.Debug,
-		}
-		w.wrapProcessor(ic)
-		cmp.producers[name] = w
-	}
-
-	// 初始化consumers
-	cmp.consumers = make(map[string]*Consumer)
-	l := &logger{cmp.logger}
-	el := &errorLogger{cmp.logger}
-	for name, cg := range c.config.Consumers {
-		r := &Consumer{
-			r: kafka.NewReader(kafka.ReaderConfig{
-				Brokers:                c.config.Brokers,
-				Topic:                  cg.Topic,
-				GroupID:                cg.GroupID,
-				Partition:              cg.Partition,
-				MinBytes:               cg.MinBytes,
-				MaxBytes:               cg.MaxBytes,
-				WatchPartitionChanges:  cg.WatchPartitionChanges,
-				PartitionWatchInterval: cg.PartitionWatchInterval,
-				RebalanceTimeout:       cg.RebalanceTimeout,
-				MaxWait:                cg.MaxWait,
-				ReadLagInterval:        cg.ReadLagInterval,
-				Logger:                 l,
-				ErrorLogger:            el,
-				HeartbeatInterval:      cg.HeartbeatInterval,
-				CommitInterval:         cg.CommitInterval,
-				SessionTimeout:         cg.SessionTimeout,
-				JoinGroupBackoff:       cg.JoinGroupBackoff,
-				RetentionTime:          cg.RetentionTime,
-				StartOffset:            cg.StartOffset,
-				ReadBackoffMin:         cg.ReadBackoffMin,
-				ReadBackoffMax:         cg.ReadBackoffMax,
-			}),
-			processor: defaultProcessor,
-			logMode:   c.config.Debug,
-		}
-		r.wrapProcessor(ic)
-		cmp.consumers[name] = r
+		config:    c.config,
+		logger:    c.logger,
+		producers: make(map[string]*Producer),
+		consumers: make(map[string]*Consumer),
 	}
 
 	return cmp
-}
-
-type logger struct {
-	*elog.Component
-}
-
-func (l *logger) Printf(tmpl string, args ...interface{}) {
-	l.Debugf(tmpl, args...)
-}
-
-type errorLogger struct {
-	*elog.Component
-}
-
-func (l *errorLogger) Printf(tmpl string, args ...interface{}) {
-	l.Errorf(tmpl, args...)
 }

--- a/ekafka/logger.go
+++ b/ekafka/logger.go
@@ -1,0 +1,29 @@
+package ekafka
+
+import "github.com/gotomicro/ego/core/elog"
+
+// errorLogger is an elog to kafka-go Logger adapter
+type logger struct {
+	*elog.Component
+}
+
+func (l *logger) Printf(tmpl string, args ...interface{}) {
+	l.Debugf(tmpl, args...)
+}
+
+// errorLogger is an elog to kafka-go ErrorLogger adapter
+type errorLogger struct {
+	*elog.Component
+}
+
+func (l *errorLogger) Printf(tmpl string, args ...interface{}) {
+	l.Errorf(tmpl, args...)
+}
+
+func newKafkaLogger(wrappedLogger *elog.Component) *logger {
+	return &logger{wrappedLogger}
+}
+
+func newKafkaErrorLogger(wrappedLogger *elog.Component) *errorLogger {
+	return &errorLogger{wrappedLogger}
+}


### PR DESCRIPTION
计划在 Component 上增加 ConsumerGroup 的封装，如果也采用现在的预先加载模式，可能会产生不必要的 rebalancing 等问题，所以在此改动之前需要把实例化方式做调整。

本次调整包含：

- 把 `Consumer()`、`Producer()` 的 receiver 改为指针（可能会要求现有使用方做调整）
- 把实例化逻辑从 Container 移到 Component 中，使用一个 Component 全局的 Mutex 做锁
