### PR TITLE
feat: 增加ConsumerGroup的封装和E2E测试

### DIFF
--- a/ekafka/Makefile
+++ b/ekafka/Makefile
@@ -1,0 +1,3 @@
+test-e2e:
+	@TEST_CONFIG=$(shell pwd)/test/e2e/config/e2e.toml go test -v ./test/e2e/...
+.PHONY: test-e2e

--- a/ekafka/README.md
+++ b/ekafka/README.md
@@ -148,3 +148,17 @@ func main() {
 	}
 }
 ```
+
+## 测试
+
+### E2E 测试
+
+> 运行 E2E 测试需要 Kafka 环境。
+
+首先将 `test/e2e/config/example.toml` 复制为 `test/e2e/config/e2e.toml` 并按实际情况修改，该文件即是运行 E2E 测试的配置文件。
+
+在模块目录下执行命令运行测试：
+
+```
+$ make test-e2e
+```

--- a/ekafka/README.md
+++ b/ekafka/README.md
@@ -32,7 +32,42 @@ topic = "my-topic"
 ```
 
 ```go
+package main
 
+import "github.com/gotomicro/ego-component/ekafka"
+
+func main() {
+	cmp := ekafka.Load("kafka").Build()
+	// 获取实例（第一次调用时初始化，再次获取时会复用）
+	cg := cmp.ConsumerGroup("cg1")
+
+	for {
+		pollCtx, _ := context.WithTimeout(ctx, 1*time.Minute)
+		// 拉取事件，可能是消息、Rebalancing 事件或者错误等
+		event, err := consumerGroup.Poll(pollCtx)
+		if err != nil {
+			elog.Panic("poll error")
+			return
+		}
+		switch e := event.(type) {
+		case ekafka.Message:
+			// 按需处理消息
+		case ekafka.AssignedPartitions:
+			// 在 Kafka 完成分区分配时触发一次
+		case ekafka.RevokedPartitions:
+			// 在当前 Generation 结束时触发一次
+		case error:
+			// 错误处理
+
+			// 结束
+			if err := cg.Close(); err != nil {
+				elog.Panic("关闭ConsumerGroup失败")
+			}
+		default:
+			// ...
+		}
+	}
+}
 ```
 
 ## Consumer Server 组件

--- a/ekafka/README.md
+++ b/ekafka/README.md
@@ -254,7 +254,11 @@ func main() {
 			// 注册处理消息的回调函数
 			cs.OnEachMessage(consumptionErrors, func(ctx context.Context, message kafka.Message) error {
 				elog.Infof("got a message: %s\n", string(message.Value))
-				// 如果返回错误则会被转发给 `consumptionErrors`
+				// 如果返回错误则会被转发给 `consumptionErrors`，默认出现任何错误都会导致消费终止、
+				// ConsumerGroup 退出；但可以将错误标记为 Retryable 以实现重试，ConsumerGroup 最多重试 3 次
+				// 如：
+				// return fmt.Errorf("%w 写入数据库时发生错误", consumerserver.ErrRecoverableError)
+
 				return nil
 			})
 

--- a/ekafka/README.md
+++ b/ekafka/README.md
@@ -70,6 +70,98 @@ func main() {
 }
 ```
 
+### 配置说明
+
+```yaml
+[kafka.consumerGroups.cg1]
+# GroupID is the name of the consumer group.
+groupID = "group-1"
+# The topic to read messages from.
+topic = "my-topic"
+# HeartbeatInterval sets the optional frequency at which the reader sends the consumer
+# group heartbeat update.
+#
+# Default: 3s
+heartbeatInterval = "3s"
+# PartitionWatchInterval indicates how often a reader checks for partition changes.
+# If a reader sees a partition change (such as a partition add) it will rebalance the group
+# picking up new partitions.
+#
+# Default: 5s
+partitionWatchInterval = "5s"
+# WatchForPartitionChanges is used to inform kafka-go that a consumer group should be
+# polling the brokers and rebalancing if any partition changes happen to the topic.
+watchPartitionChanges = false
+# SessionTimeout optionally sets the length of time that may pass without a heartbeat
+# before the coordinator considers the consumer dead and initiates a rebalance.
+#
+# Default: 30s
+sessionTimeout = "30s"
+# RebalanceTimeout optionally sets the length of time the coordinator will wait
+# for members to join as part of a rebalance.  For kafka servers under higher
+# load, it may be useful to set this value higher.
+#
+# Default: 30s
+rebalanceTimeout = "30s"
+# JoinGroupBackoff optionally sets the length of time to wait before re-joining
+# the consumer group after an error.
+#
+# Default: 5s
+joinGroupBackoff = "5s"
+# StartOffset determines from whence the consumer group should begin
+# consuming when it finds a partition without a committed offset.  If
+# non-zero, it must be set to one of FirstOffset or LastOffset.
+#
+# Default: `-2` (FirstOffset)
+startOffset = "-2"
+# RetentionTime optionally sets the length of time the consumer group will
+# be saved by the broker.  -1 will disable the setting and leave the
+# retention up to the broker's offsets.retention.minutes property.  By
+# default, that setting is 1 day for kafka < 2.0 and 7 days for kafka >=
+# 2.0.
+#
+# Default: -1
+retentionTime = "-1"
+# MinBytes indicates to the broker the minimum batch size that the consumer
+# will accept. Setting a high minimum when consuming from a low-volume topic
+# may result in delayed delivery when the broker does not have enough data to
+# satisfy the defined minimum.
+#
+# Default: 1
+minBytes = 1
+# MaxBytes indicates to the broker the maximum batch size that the consumer
+# will accept. The broker will truncate a message to satisfy this maximum, so
+# choose a value that is high enough for your largest message size.
+#
+# Default: 1MB
+maxBytes = 1048576
+# Maximum amount of time to wait for new data to come when fetching batches
+# of messages from kafka.
+#
+# Default: 10s
+maxWait = "10s"
+# ReadLagInterval sets the frequency at which the reader lag is updated.
+# Setting this field to a negative value disables lag reporting.
+#
+# Default: 60s
+readLagInterval = "60s"
+# CommitInterval indicates the interval at which offsets are committed to
+# the broker.  If 0, commits will be handled synchronously.
+#
+# Default: 0
+commitInterval = "0"
+# BackoffDelayMin optionally sets the smallest amount of time the reader will wait before
+# polling for new messages
+#
+# Default: 100ms
+readBackoffMin = "100ms"
+# BackoffDelayMax optionally sets the maximum amount of time the reader will wait before
+# polling for new messages
+#
+# Default: 1s
+readBackoffMax = "1s"
+```
+
 ## Consumer Server 组件
 
 > 必须配置 ConsumerGroup 使用。

--- a/ekafka/README.md
+++ b/ekafka/README.md
@@ -12,6 +12,29 @@
 
 生产者消费者使用样例可参考 [example](examples/main.go)
 
+## ConsumerGroup
+
+相对于 Consumer（对 [kafka-go](https://github.com/segmentio/kafka-go) 的封装）来说，ConsumerGroup 则提供了更加易用的 API。这是一个简单的例子：
+
+首先添加所需配置：
+
+```yaml
+[kafka]
+brokers = ["127.0.0.1:9092", "127.0.0.1:9093", "127.0.0.1:9094"]
+
+[kafka.client]
+timeout = "3s"
+
+[kafka.consumerGroups.cg1]
+JoinGroupBackoff = "1s"
+groupID = "group-1"
+topic = "my-topic"
+```
+
+```go
+
+```
+
 ## Consumer Server 组件
 
 > 必须配置 ConsumerGroup 使用。
@@ -153,11 +176,11 @@ func main() {
 
 ### E2E 测试
 
-> 运行 E2E 测试需要 Kafka 环境。
+> 运行 E2E 测试需要准备 Kafka 环境，推荐 3 个 broker、每 topic 3 个 partition，否则有些测试会报错。
 
 首先将 `test/e2e/config/example.toml` 复制为 `test/e2e/config/e2e.toml` 并按实际情况修改，该文件即是运行 E2E 测试的配置文件。
 
-在模块目录下执行命令运行测试：
+在 `ekafka/` 目录下执行命令运行测试：
 
 ```
 $ make test-e2e

--- a/ekafka/config.go
+++ b/ekafka/config.go
@@ -16,9 +16,11 @@ type config struct {
 	// Producers 多个消费者，用于生产消息
 	Producers map[string]producerConfig `json:"producers" toml:"producers"`
 	// Consumers 多个生产者，用于消费消息
-	Consumers    map[string]consumerConfig `json:"consumers" toml:"consumers"`
-	interceptors []Interceptor
-	balancers    map[string]Balancer
+	Consumers map[string]consumerConfig `json:"consumers" toml:"consumers"`
+	// ConsumerGroups 多个消费组，用于消费消息
+	ConsumerGroups map[string]consumerGroupConfig `json:"consumerGroups" toml:"consumerGroups"`
+	interceptors   []Interceptor
+	balancers      map[string]Balancer
 }
 
 type clientConfig struct {
@@ -81,6 +83,28 @@ type consumerConfig struct {
 	StartOffset       int64         `json:"startOffset" toml:"startOffset"`
 	ReadBackoffMin    time.Duration `json:"readBackoffMin" toml:"readBackoffMin"`
 	ReadBackoffMax    time.Duration `json:"readBackoffMax" toml:"readBackoffMax"`
+}
+
+type consumerGroupConfig struct {
+	GroupID                string                `json:"groupID" toml:"groupID"`
+	Topic                  string                `json:"topic" toml:"topic"`
+	GroupBalancers         []kafka.GroupBalancer `json:"groupBalancers" toml:"groupBalancers"`
+	HeartbeatInterval      time.Duration         `json:"heartbeatInterval" toml:"heartbeatInterval"`
+	PartitionWatchInterval time.Duration         `json:"partitionWatchInterval" toml:"partitionWatchInterval"`
+	WatchPartitionChanges  bool                  `json:"watchPartitionChanges" toml:"watchPartitionChanges"`
+	SessionTimeout         time.Duration         `json:"sessionTimeout" toml:"sessionTimeout"`
+	RebalanceTimeout       time.Duration         `json:"rebalanceTimeout" toml:"rebalanceTimeout"`
+	JoinGroupBackoff       time.Duration         `json:"joinGroupBackoff" toml:"joinGroupBackoff"`
+	StartOffset            int64                 `json:"startOffset" toml:"startOffset"`
+	RetentionTime          time.Duration         `json:"retentionTime" toml:"retentionTime"`
+	// Reader otpions:
+	MinBytes        int           `json:"minBytes" toml:"minBytes"`
+	MaxBytes        int           `json:"maxBytes" toml:"maxBytes"`
+	MaxWait         time.Duration `json:"maxWait" toml:"maxWait"`
+	ReadLagInterval time.Duration `json:"readLagInterval" toml:"readLagInterval"`
+	CommitInterval  time.Duration `json:"commitInterval" toml:"commitInterval"`
+	ReadBackoffMin  time.Duration `json:"readBackoffMin" toml:"readBackoffMin"`
+	ReadBackoffMax  time.Duration `json:"readBackoffMax" toml:"readBackoffMax"`
 }
 
 const (

--- a/ekafka/consumergroup.go
+++ b/ekafka/consumergroup.go
@@ -221,7 +221,7 @@ func (cg *ConsumerGroup) CommitMessages(ctx context.Context, messages ...Message
 	for _, message := range messages {
 		messageOffset := message.Offset + 1
 		currentOffset, ok := partitions[message.Partition]
-		if ok && messageOffset > currentOffset {
+		if ok && currentOffset >= messageOffset {
 			continue
 		}
 		partitions[message.Partition] = messageOffset

--- a/ekafka/consumergroup.go
+++ b/ekafka/consumergroup.go
@@ -1,0 +1,244 @@
+package ekafka
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/gotomicro/ego/core/elog"
+	"github.com/segmentio/kafka-go"
+)
+
+type TopicPartition struct {
+	Topic     string
+	Partition int
+	Offset    int64
+}
+
+type AssignedPartitions struct {
+	Partitions []TopicPartition
+}
+
+type RevokedPartitions struct {
+	Partitions []TopicPartition
+}
+
+type ConsumerGroup struct {
+	logger     *elog.Component
+	group      *kafka.ConsumerGroup
+	events     chan interface{}
+	options    *ConsumerGroupOptions
+	currentGen *kafka.Generation
+	genMu      sync.RWMutex
+	readerWg   sync.WaitGroup
+}
+
+func createTopicPartitionsFromGenAssignments(genAssignments map[string][]kafka.PartitionAssignment) []TopicPartition {
+	topicPartitions := make([]TopicPartition, 0)
+	for topic, assignments := range genAssignments {
+		for _, assignment := range assignments {
+			topicPartitions = append(topicPartitions, TopicPartition{
+				Topic:     topic,
+				Partition: assignment.ID,
+				Offset:    assignment.Offset,
+			})
+		}
+	}
+	return topicPartitions
+}
+
+type readerOptions struct {
+	MinBytes        int
+	MaxBytes        int
+	MaxWait         time.Duration
+	ReadLagInterval time.Duration
+	CommitInterval  time.Duration
+	ReadBackoffMin  time.Duration
+	ReadBackoffMax  time.Duration
+}
+
+type ConsumerGroupOptions struct {
+	Logger                 *elog.Component
+	Brokers                []string
+	GroupID                string
+	Topic                  string
+	HeartbeatInterval      time.Duration
+	PartitionWatchInterval time.Duration
+	WatchPartitionChanges  bool
+	SessionTimeout         time.Duration
+	RebalanceTimeout       time.Duration
+	JoinGroupBackoff       time.Duration
+	StartOffset            int64
+	RetentionTime          time.Duration
+	Reader                 readerOptions
+}
+
+func NewConsumerGroup(options ConsumerGroupOptions) (*ConsumerGroup, error) {
+	logger := newKafkaLogger(options.Logger)
+	errorLogger := newKafkaErrorLogger(options.Logger)
+	group, err := kafka.NewConsumerGroup(kafka.ConsumerGroupConfig{
+		Brokers:                options.Brokers,
+		ID:                     options.GroupID,
+		Topics:                 []string{options.Topic},
+		HeartbeatInterval:      options.HeartbeatInterval,
+		PartitionWatchInterval: options.PartitionWatchInterval,
+		WatchPartitionChanges:  options.WatchPartitionChanges,
+		SessionTimeout:         options.SessionTimeout,
+		RebalanceTimeout:       options.RebalanceTimeout,
+		JoinGroupBackoff:       options.JoinGroupBackoff,
+		StartOffset:            options.StartOffset,
+		RetentionTime:          options.RetentionTime,
+		Logger:                 logger,
+		ErrorLogger:            errorLogger,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	cg := &ConsumerGroup{
+		logger:  options.Logger,
+		group:   group,
+		events:  make(chan interface{}, 100),
+		options: &options,
+	}
+	go cg.run()
+
+	return cg, nil
+}
+
+func (cg *ConsumerGroup) run() {
+	cg.readerWg.Add(1)
+	defer cg.readerWg.Done()
+
+	for {
+		gen, err := cg.group.Next(context.TODO())
+		cg.genMu.Lock()
+		cg.currentGen = gen
+		cg.genMu.Unlock()
+
+		if err != nil {
+			if errors.Is(err, kafka.ErrGroupClosed) {
+				return
+			}
+
+			cg.events <- err
+			return
+		}
+
+		// Organize partitions
+		topicPartitions := createTopicPartitionsFromGenAssignments(gen.Assignments)
+
+		// We could have multiple Readers but we only want to emit RevokedPartitions event once
+		var revokeOnce sync.Once
+
+		// Emit AssignedPartitions event
+		cg.events <- AssignedPartitions{
+			Partitions: topicPartitions,
+		}
+
+		// We don't support multiple topics yet.
+		assignments, ok := gen.Assignments[cg.options.Topic]
+		if !ok {
+			cg.events <- fmt.Errorf("topic \"%s\" not found in assignments", cg.options.Topic)
+			break
+		}
+
+		// Listen to all partitions
+		for _, assignment := range assignments {
+			partition, offset := assignment.ID, assignment.Offset
+
+			logger := newKafkaLogger(cg.logger)
+			errorLogger := newKafkaErrorLogger(cg.logger)
+			gen.Start(func(ctx context.Context) {
+				reader := kafka.NewReader(kafka.ReaderConfig{
+					Brokers:         cg.options.Brokers,
+					Topic:           cg.options.Topic,
+					Partition:       partition,
+					MinBytes:        cg.options.Reader.MinBytes,
+					MaxBytes:        cg.options.Reader.MaxBytes,
+					MaxWait:         cg.options.Reader.MaxWait,
+					ReadLagInterval: cg.options.Reader.ReadLagInterval,
+					Logger:          logger,
+					ErrorLogger:     errorLogger,
+					CommitInterval:  cg.options.Reader.CommitInterval,
+					ReadBackoffMin:  cg.options.Reader.ReadBackoffMin,
+					ReadBackoffMax:  cg.options.Reader.ReadBackoffMax,
+				})
+				defer reader.Close()
+
+				// seek to the last committed offset for this partition.
+				reader.SetOffset(offset)
+				for {
+					msg, err := reader.FetchMessage(ctx)
+
+					switch err {
+					case kafka.ErrGroupClosed:
+						return
+					case kafka.ErrGenerationEnded:
+						// emit RevokedPartitions event
+						revokeOnce.Do(func() {
+							cg.events <- RevokedPartitions{
+								Partitions: topicPartitions,
+							}
+						})
+
+						return
+					case io.EOF:
+						// Reader has been closed
+						return
+					case nil:
+						// message received.
+						cg.events <- Message(msg)
+					default:
+						cg.events <- err
+					}
+				}
+			})
+		}
+	}
+}
+
+func (cg *ConsumerGroup) Poll(ctx context.Context) (interface{}, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case msg := <-cg.events:
+		return msg, nil
+	}
+}
+
+func (cg *ConsumerGroup) CommitMessages(ctx context.Context, messages ...Message) error {
+	cg.genMu.RLock()
+	if cg.currentGen == nil {
+		cg.genMu.RUnlock()
+		return fmt.Errorf("generation haven't been created yet")
+	}
+
+	partitions := make(map[int]int64)
+	for _, message := range messages {
+		messageOffset := message.Offset + 1
+		currentOffset, ok := partitions[message.Partition]
+		if ok && messageOffset > currentOffset {
+			continue
+		}
+		partitions[message.Partition] = messageOffset
+	}
+
+	offsets := make(map[string]map[int]int64)
+	offsets[cg.options.Topic] = partitions
+
+	err := cg.currentGen.CommitOffsets(offsets)
+	cg.genMu.RUnlock()
+
+	return err
+}
+
+func (cg *ConsumerGroup) Close() (err error) {
+	err = cg.group.Close()
+	cg.readerWg.Wait()
+	close(cg.events)
+	return
+}

--- a/ekafka/consumerserver/component.go
+++ b/ekafka/consumerserver/component.go
@@ -93,13 +93,13 @@ func (cmp *Component) Start() error {
 	}
 }
 
-// GetConsumer returns the default Consumer.
-func (cmp *Component) GetConsumer() *ekafka.Consumer {
+// Consumer returns the default Consumer.
+func (cmp *Component) Consumer() *ekafka.Consumer {
 	return cmp.ekafkaComponent.Consumer(cmp.config.ConsumerName)
 }
 
-// GetConsumerGroup returns the default ConsumerGroup.
-func (cmp *Component) GetConsumerGroup() *ekafka.ConsumerGroup {
+// ConsumerGroup returns the default ConsumerGroup.
+func (cmp *Component) ConsumerGroup() *ekafka.ConsumerGroup {
 	return cmp.ekafkaComponent.ConsumerGroup(cmp.config.ConsumerGroupName)
 }
 
@@ -135,7 +135,7 @@ func isErrorUnrecoverable(err error) bool {
 }
 
 func (cmp *Component) launchOnConsumerGroupStart() error {
-	consumerGroup := cmp.GetConsumerGroup()
+	consumerGroup := cmp.ConsumerGroup()
 
 	if cmp.onConsumerGroupStartHandler == nil {
 		return errors.New("you must define a MessageHandler first")
@@ -181,7 +181,7 @@ func (cmp *Component) launchOnConsumerGroupStart() error {
 }
 
 func (cmp *Component) launchOnConsumerStart() error {
-	consumer := cmp.GetConsumer()
+	consumer := cmp.Consumer()
 
 	if cmp.onConsumerStartHandler == nil {
 		return errors.New("you must define a MessageHandler first")
@@ -227,7 +227,7 @@ func (cmp *Component) launchOnConsumerStart() error {
 }
 
 func (cmp *Component) launchOnConsumerEachMessage() error {
-	consumer := cmp.GetConsumer()
+	consumer := cmp.Consumer()
 
 	if cmp.onEachMessageHandler == nil {
 		return errors.New("you must define a MessageHandler first")

--- a/ekafka/consumerserver/component.go
+++ b/ekafka/consumerserver/component.go
@@ -21,22 +21,24 @@ const PackageName = "component.ekafka.consumerserver"
 type consumptionMode int
 
 const (
-	consumptionModeManual consumptionMode = iota + 1
-	consumptionModeSingle
+	consumptionModeOnConsumerStart consumptionMode = iota + 1
+	consumptionModeOnConsumerEachMessage
+	consumptionModeOnConsumerGroupStart
 )
 
 // Component starts an Ego server for message consuming.
 type Component struct {
-	ServerCtx             context.Context
-	stopServer            context.CancelFunc
-	config                *config
-	name                  string
-	ekafkaComponent       *ekafka.Component
-	logger                *elog.Component
-	mode                  consumptionMode
-	onEachMessageHandler  OnEachMessageHandler
-	onStartMessageHandler OnStartHandler
-	consumptionErrors     chan<- error
+	ServerCtx                   context.Context
+	stopServer                  context.CancelFunc
+	config                      *config
+	name                        string
+	ekafkaComponent             *ekafka.Component
+	logger                      *elog.Component
+	mode                        consumptionMode
+	onEachMessageHandler        OnEachMessageHandler
+	onConsumerStartHandler      OnStartHandler
+	onConsumerGroupStartHandler OnConsumerGroupStartHandler
+	consumptionErrors           chan<- error
 }
 
 // PackageName returns the package name.
@@ -77,32 +79,46 @@ func (cmp *Component) Name() string {
 // Start will start consuming.
 func (cmp *Component) Start() error {
 	switch cmp.mode {
-	case consumptionModeManual:
-		return cmp.startManualMode()
-	case consumptionModeSingle:
-		return cmp.startSingleMode()
+	case consumptionModeOnConsumerStart:
+		return cmp.launchOnConsumerStart()
+	case consumptionModeOnConsumerGroupStart:
+		return cmp.launchOnConsumerGroupStart()
+	case consumptionModeOnConsumerEachMessage:
+		return cmp.launchOnConsumerEachMessage()
 	default:
 		return fmt.Errorf("undefined consumption mode: %v", cmp.mode)
 	}
 }
 
-// GetConsumer returns the default consumer.
+// GetConsumer returns the default Consumer.
 func (cmp *Component) GetConsumer() *ekafka.Consumer {
 	return cmp.ekafkaComponent.Consumer(cmp.config.ConsumerName)
 }
 
-// OnEachMessage registers a single message handler.
+// GetConsumerGroup returns the default ConsumerGroup.
+func (cmp *Component) GetConsumerGroup() *ekafka.ConsumerGroup {
+	return cmp.ekafkaComponent.ConsumerGroup(cmp.config.ConsumerGroupName)
+}
+
+// OnEachMessage ...
 func (cmp *Component) OnEachMessage(consumptionErrors chan<- error, handler OnEachMessageHandler) error {
 	cmp.consumptionErrors = consumptionErrors
-	cmp.mode = consumptionModeSingle
+	cmp.mode = consumptionModeOnConsumerEachMessage
 	cmp.onEachMessageHandler = handler
 	return nil
 }
 
-// OnStart registers a manual message handler.
+// OnStart ...
 func (cmp *Component) OnStart(handler OnStartHandler) error {
-	cmp.mode = consumptionModeManual
-	cmp.onStartMessageHandler = handler
+	cmp.mode = consumptionModeOnConsumerStart
+	cmp.onConsumerStartHandler = handler
+	return nil
+}
+
+// OnConsumerGroupStart ...
+func (cmp *Component) OnConsumerGroupStart(handler OnConsumerGroupStartHandler) error {
+	cmp.mode = consumptionModeOnConsumerGroupStart
+	cmp.onConsumerGroupStartHandler = handler
 	return nil
 }
 
@@ -115,16 +131,16 @@ func isErrorUnrecoverable(err error) bool {
 	return true
 }
 
-func (cmp *Component) startManualMode() error {
-	consumer := cmp.GetConsumer()
+func (cmp *Component) launchOnConsumerGroupStart() error {
+	consumerGroup := cmp.GetConsumerGroup()
 
-	if cmp.onStartMessageHandler == nil {
+	if cmp.onConsumerGroupStartHandler == nil {
 		return errors.New("you must define a MessageHandler first")
 	}
 
 	handlerExit := make(chan error)
 	go func() {
-		handlerExit <- cmp.onStartMessageHandler(cmp.ServerCtx, consumer)
+		handlerExit <- cmp.onConsumerGroupStartHandler(cmp.ServerCtx, consumerGroup)
 		close(handlerExit)
 	}()
 
@@ -132,26 +148,26 @@ func (cmp *Component) startManualMode() error {
 	select {
 	case originErr := <-handlerExit:
 		if originErr != nil {
-			cmp.logger.Error("terminating consumer because an error", elog.FieldErr(originErr))
+			cmp.logger.Error("terminating ConsumerServer because an error", elog.FieldErr(originErr))
 		} else {
-			cmp.logger.Info("message handler exited without any error, terminating consumer server")
+			cmp.logger.Info("message handler exited without any error, terminating ConsumerServer")
 		}
 		cmp.stopServer()
 	case <-cmp.ServerCtx.Done():
 		originErr := cmp.ServerCtx.Err()
-		cmp.logger.Error("terminating consumer because a context error", elog.FieldErr(originErr))
+		cmp.logger.Error("terminating ConsumerServer because a context error", elog.FieldErr(originErr))
 
 		err := <-handlerExit
 		if err != nil {
-			cmp.logger.Error("terminating consumer because an error", elog.FieldErr(err))
+			cmp.logger.Error("terminating ConsumerServer because an error", elog.FieldErr(err))
 		} else {
 			cmp.logger.Info("message handler exited without any error")
 		}
 	}
 
-	err := cmp.closeConsumer(consumer)
+	err := cmp.closeConsumerGroup(consumerGroup)
 	if err != nil {
-		return fmt.Errorf("encountered an error while closing consumer: %w", err)
+		return fmt.Errorf("encountered an error while closing ConsumerGroup: %w", err)
 	}
 
 	if errors.Is(originErr, context.Canceled) {
@@ -161,7 +177,53 @@ func (cmp *Component) startManualMode() error {
 	return originErr
 }
 
-func (cmp *Component) startSingleMode() error {
+func (cmp *Component) launchOnConsumerStart() error {
+	consumer := cmp.GetConsumer()
+
+	if cmp.onConsumerStartHandler == nil {
+		return errors.New("you must define a MessageHandler first")
+	}
+
+	handlerExit := make(chan error)
+	go func() {
+		handlerExit <- cmp.onConsumerStartHandler(cmp.ServerCtx, consumer)
+		close(handlerExit)
+	}()
+
+	var originErr error
+	select {
+	case originErr := <-handlerExit:
+		if originErr != nil {
+			cmp.logger.Error("terminating ConsumerGroup because an error", elog.FieldErr(originErr))
+		} else {
+			cmp.logger.Info("message handler exited without any error, terminating ConsumerGroup")
+		}
+		cmp.stopServer()
+	case <-cmp.ServerCtx.Done():
+		originErr := cmp.ServerCtx.Err()
+		cmp.logger.Error("terminating ConsumerGroup because a context error", elog.FieldErr(originErr))
+
+		err := <-handlerExit
+		if err != nil {
+			cmp.logger.Error("terminating ConsumerGroup because an error", elog.FieldErr(err))
+		} else {
+			cmp.logger.Info("message handler exited without any error")
+		}
+	}
+
+	err := cmp.closeConsumer(consumer)
+	if err != nil {
+		return fmt.Errorf("encountered an error while closing Consumer: %w", err)
+	}
+
+	if errors.Is(originErr, context.Canceled) {
+		return nil
+	}
+
+	return originErr
+}
+
+func (cmp *Component) launchOnConsumerEachMessage() error {
 	consumer := cmp.GetConsumer()
 
 	if cmp.onEachMessageHandler == nil {
@@ -256,10 +318,19 @@ func (cmp *Component) startSingleMode() error {
 
 func (cmp *Component) closeConsumer(consumer *ekafka.Consumer) error {
 	if err := consumer.Close(); err != nil {
-		cmp.logger.Fatal("failed to close kafka writer", elog.FieldErr(err))
+		cmp.logger.Fatal("failed to close Consumer", elog.FieldErr(err))
 		return err
 	}
-	cmp.logger.Info("consumer server terminated")
+	cmp.logger.Info("Consumer closed")
+	return nil
+}
+
+func (cmp *Component) closeConsumerGroup(consumerGroup *ekafka.ConsumerGroup) error {
+	if err := consumerGroup.Close(); err != nil {
+		cmp.logger.Fatal("failed to close ConsumerGroup", elog.FieldErr(err))
+		return err
+	}
+	cmp.logger.Info("ConsumerGroup closed")
 	return nil
 }
 
@@ -273,6 +344,6 @@ func NewConsumerServerComponent(name string, config *config, ekafkaComponent *ek
 		config:          config,
 		ekafkaComponent: ekafkaComponent,
 		logger:          logger,
-		mode:            consumptionModeSingle,
+		mode:            consumptionModeOnConsumerEachMessage,
 	}
 }

--- a/ekafka/consumerserver/config.go
+++ b/ekafka/consumerserver/config.go
@@ -3,15 +3,17 @@ package consumerserver
 import "github.com/gotomicro/ego-component/ekafka"
 
 type config struct {
-	Debug           bool   `json:"debug" toml:"debug"`
-	ConsumerName    string `json:"consumerName" toml:"consumerName"`
-	ekafkaComponent *ekafka.Component
+	Debug             bool   `json:"debug" toml:"debug"`
+	ConsumerName      string `json:"consumerName" toml:"consumerName"`
+	ConsumerGroupName string `json:"consumerGroupName" toml:"consumerGroupName"`
+	ekafkaComponent   *ekafka.Component
 }
 
 // DefaultConfig returns a default config.
 func DefaultConfig() *config {
 	return &config{
-		Debug:        true,
-		ConsumerName: "default",
+		Debug:             true,
+		ConsumerName:      "default",
+		ConsumerGroupName: "default",
 	}
 }

--- a/ekafka/consumerserver/errors.go
+++ b/ekafka/consumerserver/errors.go
@@ -1,0 +1,5 @@
+package consumerserver
+
+import "errors"
+
+var ErrRecoverableError error = errors.New("recoverable error is retryable")

--- a/ekafka/consumerserver/handler.go
+++ b/ekafka/consumerserver/handler.go
@@ -12,3 +12,6 @@ type OnEachMessageHandler = func(ctx context.Context, message kafka.Message) err
 
 // OnStartHandler ...
 type OnStartHandler = func(ctx context.Context, consumer *ekafka.Consumer) error
+
+// OnConsumerGroupStartHandler ...
+type OnConsumerGroupStartHandler = func(ctx context.Context, consumerGroup *ekafka.ConsumerGroup) error

--- a/ekafka/container.go
+++ b/ekafka/container.go
@@ -50,10 +50,11 @@ func (c *Container) Build(options ...Option) *Component {
 
 	c.logger = c.logger.With(elog.FieldAddr(fmt.Sprintf("%s", c.config.Brokers)))
 	cmp := &Component{
-		config:    c.config,
-		logger:    c.logger,
-		producers: make(map[string]*Producer),
-		consumers: make(map[string]*Consumer),
+		config:         c.config,
+		logger:         c.logger,
+		producers:      make(map[string]*Producer),
+		consumers:      make(map[string]*Consumer),
+		consumerGroups: make(map[string]*ConsumerGroup),
 	}
 
 	return cmp

--- a/ekafka/go.mod
+++ b/ekafka/go.mod
@@ -5,7 +5,8 @@ go 1.15
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/gotomicro/ego v0.4.3-0.20210325095314-1c7eb82de631
-	github.com/segmentio/kafka-go v0.4.8
+	github.com/klauspost/compress v1.12.1 // indirect
+	github.com/segmentio/kafka-go v0.4.15
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
 	golang.org/x/tools v0.0.0-20200426102838-f3a5411a4c3b // indirect

--- a/ekafka/go.sum
+++ b/ekafka/go.sum
@@ -60,6 +60,8 @@ github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
+github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -85,6 +87,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.9.8 h1:VMAMUUOh+gaxKTMk+zqbjsSjsIcUcL/LF4o63i82QyA=
 github.com/klauspost/compress v1.9.8/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/compress v1.12.1 h1:/+xsCsk06wE38cyiqOR/o7U2fSftcH72xD+BQXmja/g=
+github.com/klauspost/compress v1.12.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -141,6 +145,8 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/segmentio/kafka-go v0.4.8 h1:LO36H2tb7RcCRjsYzT/qf7xE+vRBXgddZDD82e1eiWY=
 github.com/segmentio/kafka-go v0.4.8/go.mod h1:Inh7PqOsxmfgasV8InZYKVXWsdjcCq2d9tFV75GLbuM=
+github.com/segmentio/kafka-go v0.4.15 h1:cEcaQX2cTenDH3LIMFfIQNzGxYWGNMp0LdWmYv89h64=
+github.com/segmentio/kafka-go v0.4.15/go.mod h1:19+Eg7KwrNKy/PFhiIthEPkO8k+ac7/ZYXwYM9Df10w=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/ekafka/test/e2e/config.go
+++ b/ekafka/test/e2e/config.go
@@ -1,0 +1,25 @@
+package e2e
+
+import (
+	"os"
+
+	"github.com/BurntSushi/toml"
+	"github.com/gotomicro/ego/core/econf"
+)
+
+func init() {
+	configFilePath := os.Getenv("TEST_CONFIG")
+
+	f, err := os.Open(configFilePath)
+	if err != nil {
+		panic(err)
+	}
+
+	err = econf.LoadFromReader(f, toml.Unmarshal)
+	if err != nil {
+		panic(err)
+	}
+	if err := f.Close(); err != nil {
+		panic(err)
+	}
+}

--- a/ekafka/test/e2e/config/.gitignore
+++ b/ekafka/test/e2e/config/.gitignore
@@ -1,0 +1,2 @@
+*.toml
+!example.toml

--- a/ekafka/test/e2e/config/example.toml
+++ b/ekafka/test/e2e/config/example.toml
@@ -1,0 +1,24 @@
+# 将该文件复制一份到同级目录下，并重命名为 `test.toml` 作为 E2E 测试的配置
+
+[kafka]
+brokers = ["localhost:9094"]
+
+[kafka.client]
+timeout = "3s"
+
+[kafka.producers.p1]
+commitInterval = "1s"
+heartbeatInterval = "1s"
+topic = "sre-infra-test"
+
+[kafka.consumers.c1]
+JoinGroupBackoff = "1s"
+groupID = "test-group-1"
+heartbeatInterval = "1s"
+maxBytes = 1500
+minBytes = 100
+partitionWatchInterval = "1s"
+topic = "sre-infra-test"
+
+[kafkaConsumerServers.s1]
+consumerName = "c1"

--- a/ekafka/test/e2e/consumergroup_test.go
+++ b/ekafka/test/e2e/consumergroup_test.go
@@ -1,0 +1,139 @@
+package e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gotomicro/ego-component/ekafka"
+	"github.com/segmentio/kafka-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func consumerGroupConsume(
+	consumerGroup *ekafka.ConsumerGroup,
+	ctx context.Context,
+	consumedCh chan<- struct{},
+	consumerGroupErrCh chan<- error,
+	expectedMessage string,
+	assignedPartitionsEventCount *int32,
+	revokedPartitionsEventCount *int32,
+) {
+	for {
+		pollCtx, _ := context.WithTimeout(ctx, 1*time.Minute)
+		event, err := consumerGroup.Poll(pollCtx)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			consumerGroupErrCh <- err
+			return
+		}
+		switch e := event.(type) {
+		case ekafka.Message:
+			received := string(e.Value)
+			if received == expectedMessage {
+				commitCtx, _ := context.WithTimeout(ctx, 10*time.Second)
+				err := consumerGroup.CommitMessages(commitCtx, ekafka.Message{
+					Partition: e.Partition,
+					Offset:    e.Offset,
+				})
+				if err != nil {
+					if errors.Is(err, context.Canceled) {
+						return
+					}
+					consumerGroupErrCh <- err
+					return
+				}
+
+				if err := consumerGroup.Close(); err != nil {
+					consumerGroupErrCh <- err
+					return
+				}
+
+				consumedCh <- struct{}{}
+				return
+			}
+		case ekafka.AssignedPartitions:
+			atomic.AddInt32(assignedPartitionsEventCount, 1)
+		case ekafka.RevokedPartitions:
+			atomic.AddInt32(revokedPartitionsEventCount, 1)
+		case error:
+			consumerGroupErrCh <- e
+		default:
+			consumerGroupErrCh <- fmt.Errorf("不应该收到任何其他消息")
+		}
+	}
+}
+
+// 启动两个 consumer（ConsumerGroup）同时消费，测试：
+// - 两方都可以收到 AssignedPartitions Event
+// - 一方可以收到 RevokedPartitions Event
+// - 一方可以消费到消息
+func Test_ConsumeWithConsumerGroup(t *testing.T) {
+	cmp := ekafka.Load("kafka").Build(
+		ekafka.WithRegisterBalancer("my-balancer", &kafka.Hash{}),
+	)
+
+	randomMessage := RandomString(16)
+
+	var assignedPartitionsEventCount int32 = 0
+	var revokedPartitionsEventCount int32 = 0
+
+	// 写一条随机字符串消息
+	producerErr := make(chan error, 1)
+	producer := cmp.Producer("p1")
+	go func() {
+		time.Sleep(45 * time.Second)
+		writeMessage(producer, randomMessage, producerErr)
+	}()
+
+	consumed := make(chan struct{}, 1)
+	consumerGroupErr := make(chan error, 1)
+	consumeCtx, cancelConsume := context.WithCancel(context.Background())
+	defer cancelConsume()
+
+	consumerGroup1 := cmp.ConsumerGroup("cg1")
+	go consumerGroupConsume(
+		consumerGroup1,
+		consumeCtx,
+		consumed,
+		consumerGroupErr,
+		randomMessage,
+		&assignedPartitionsEventCount,
+		&revokedPartitionsEventCount,
+	)
+
+	go func() {
+		time.Sleep(30 * time.Second)
+		consumerGroup2 := cmp.ConsumerGroup("cg2")
+		consumerGroupConsume(
+			consumerGroup2,
+			consumeCtx,
+			consumed,
+			consumerGroupErr,
+			randomMessage,
+			&assignedPartitionsEventCount,
+			&revokedPartitionsEventCount,
+		)
+	}()
+
+	select {
+	case <-consumed:
+		// 只要消费成功则关闭所有消费者
+		cancelConsume()
+
+		// 因为有两个 ConsumerGroup 实例，所以应该收到：
+		// - 2 次 AssignedPartitions Event
+		// - 1 次 RevokedPartitions Event
+		assert.Equal(t, int32(3), assignedPartitionsEventCount)
+		assert.Equal(t, int32(1), revokedPartitionsEventCount)
+	case err := <-consumerGroupErr:
+		t.Errorf("消费者发生错误: %s", err)
+	case err := <-producerErr:
+		t.Errorf("生产者发生错误: %s", err)
+	}
+}

--- a/ekafka/test/e2e/consumergroup_test.go
+++ b/ekafka/test/e2e/consumergroup_test.go
@@ -126,8 +126,8 @@ func Test_ConsumeWithConsumerGroup(t *testing.T) {
 		// 只要消费成功则关闭所有消费者
 		cancelConsume()
 
-		// 因为有两个 ConsumerGroup 实例，所以应该收到：
-		// - 2 次 AssignedPartitions Event
+		// 因为有两个 ConsumerGroup 实例，一个先启动、一个后启动，所以应该收到：
+		// - 3 次 AssignedPartitions Event
 		// - 1 次 RevokedPartitions Event
 		assert.Equal(t, int32(3), assignedPartitionsEventCount)
 		assert.Equal(t, int32(1), revokedPartitionsEventCount)

--- a/ekafka/test/e2e/consumerserver_test.go
+++ b/ekafka/test/e2e/consumerserver_test.go
@@ -1,0 +1,196 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gotomicro/ego-component/ekafka"
+	"github.com/gotomicro/ego-component/ekafka/consumerserver"
+	"github.com/segmentio/kafka-go"
+	"github.com/stretchr/testify/assert"
+)
+
+// 测试 ConsumeServer 的 OnConsumerEachMessage 方法
+// 写入一条随机内容的消息然后验证是否能消费到
+func Test_ConsumeServer_OnConsumerEachMessage(t *testing.T) {
+	ekafkaComponent := ekafka.Load("kafka").Build()
+
+	randomMessage := RandomString(16)
+
+	// 写一条随机字符串消息
+	producer := ekafkaComponent.Producer("p1")
+	producerErr := make(chan error, 1)
+	go writeMessage(producer, randomMessage, producerErr)
+
+	// 尝试消费 producer 推送的随机字符串消息
+	consumed := make(chan struct{}, 1)
+	consumptionErr := make(chan error, 10)
+	go func() {
+		consumerServerComponent := consumerserver.Load("kafkaConsumerServers.c1").Build(
+			consumerserver.WithEkafka(ekafkaComponent),
+		)
+
+		stopConsumerServer := make(chan struct{})
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		consumerServerComponent.OnEachMessage(
+			consumptionErr,
+			func(ctx context.Context, message kafka.Message) error {
+				received := string(message.Value)
+				if received == randomMessage {
+					consumed <- struct{}{}
+				}
+				return nil
+			},
+		)
+		if err := consumerServerComponent.Start(); err != nil {
+			consumptionErr <- err
+		}
+
+		select {
+		case <-timeoutCtx.Done():
+		case <-stopConsumerServer:
+		}
+		if err := consumerServerComponent.Stop(); err != nil {
+			consumptionErr <- err
+		}
+	}()
+
+	select {
+	case <-consumed:
+		// 成功
+	case err := <-consumptionErr:
+		t.Errorf("消费者发生错误: %s", err)
+	case err := <-producerErr:
+		t.Errorf("生产者发生错误: %s", err)
+	}
+}
+
+// 测试 ConsumeServer 的 OnConsumerStart 方法
+// 写入一条随机内容的消息然后验证是否能消费到
+func Test_ConsumeServer_OnConsumerStart(t *testing.T) {
+	ekafkaComponent := ekafka.Load("kafka").Build()
+
+	randomMessage := RandomString(16)
+
+	// 写一条随机字符串消息
+	producer := ekafkaComponent.Producer("p1")
+	producerErr := make(chan error, 1)
+	go writeMessage(producer, randomMessage, producerErr)
+
+	// 尝试消费 producer 推送的随机字符串消息
+	consumed := make(chan struct{}, 1)
+	consumptionErr := make(chan error, 10)
+	go func() {
+		consumerServerComponent := consumerserver.Load("kafkaConsumerServers.c1").Build(
+			consumerserver.WithEkafka(ekafkaComponent),
+		)
+
+		stopConsumerServer := make(chan struct{})
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		consumerServerComponent.OnStart(
+			func(ctx context.Context, consumer *ekafka.Consumer) error {
+				for {
+					msg, err := consumer.ReadMessage(ctx)
+					if err != nil {
+						return err
+					}
+					received := string(msg.Value)
+					if received == randomMessage {
+						consumed <- struct{}{}
+						return nil
+					}
+				}
+			},
+		)
+		if err := consumerServerComponent.Start(); err != nil {
+			consumptionErr <- err
+		}
+
+		select {
+		case <-timeoutCtx.Done():
+		case <-stopConsumerServer:
+		}
+		if err := consumerServerComponent.Stop(); err != nil {
+			consumptionErr <- err
+		}
+	}()
+
+	select {
+	case <-consumed:
+		// 成功
+	case err := <-consumptionErr:
+		t.Errorf("消费者发生错误: %s", err)
+	case err := <-producerErr:
+		t.Errorf("生产者发生错误: %s", err)
+	}
+}
+
+// 测试 ConsumeServer 的 OnConsumerGroupStart 方法
+// 写入一条随机内容的消息然后验证是否能消费到
+func Test_ConsumeServer_OnConsumerGroupStart(t *testing.T) {
+	ekafkaComponent := ekafka.Load("kafka").Build()
+
+	randomMessage := RandomString(16)
+
+	var assignedPartitionsEventCount int32 = 0
+	var revokedPartitionsEventCount int32 = 0
+
+	// 写一条随机字符串消息
+	producer := ekafkaComponent.Producer("p1")
+	producerErr := make(chan error, 1)
+	go writeMessage(producer, randomMessage, producerErr)
+
+	// 尝试消费 producer 推送的随机字符串消息
+	consumed := make(chan struct{}, 1)
+	consumptionErr := make(chan error, 10)
+	go func() {
+		consumerServerComponent := consumerserver.Load("kafkaConsumerServers.cg1").Build(
+			consumerserver.WithEkafka(ekafkaComponent),
+		)
+
+		stopConsumerServer := make(chan struct{})
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
+
+		consumerServerComponent.OnConsumerGroupStart(
+			func(ctx context.Context, consumerGroup *ekafka.ConsumerGroup) error {
+				consumerGroupConsume(
+					consumerGroup,
+					ctx,
+					consumed,
+					consumptionErr,
+					randomMessage,
+					&assignedPartitionsEventCount,
+					&revokedPartitionsEventCount,
+				)
+				return nil
+			},
+		)
+		if err := consumerServerComponent.Start(); err != nil {
+			consumptionErr <- err
+		}
+
+		select {
+		case <-timeoutCtx.Done():
+		case <-stopConsumerServer:
+		}
+		if err := consumerServerComponent.Stop(); err != nil {
+			consumptionErr <- err
+		}
+	}()
+
+	select {
+	case <-consumed:
+		assert.Equal(t, int32(1), assignedPartitionsEventCount)
+		assert.Equal(t, int32(0), revokedPartitionsEventCount)
+	case err := <-consumptionErr:
+		t.Errorf("消费者发生错误: %s", err)
+	case err := <-producerErr:
+		t.Errorf("生产者发生错误: %s", err)
+	}
+}

--- a/ekafka/test/e2e/helpers.go
+++ b/ekafka/test/e2e/helpers.go
@@ -1,0 +1,25 @@
+package e2e
+
+import (
+	"context"
+	"time"
+
+	"github.com/gotomicro/ego-component/ekafka"
+)
+
+func writeMessage(producer *ekafka.Producer, message string, errCh chan<- error) {
+	writeCtx, _ := context.WithTimeout(context.Background(), 30*time.Second)
+	err := producer.WriteMessages(
+		writeCtx,
+		ekafka.Message{Value: []byte(message)},
+	)
+	if err != nil {
+		errCh <- err
+		return
+	}
+
+	if err := producer.Close(); err != nil {
+		errCh <- err
+		return
+	}
+}

--- a/ekafka/test/e2e/producer_and_consumer_test.go
+++ b/ekafka/test/e2e/producer_and_consumer_test.go
@@ -1,0 +1,60 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gotomicro/ego-component/ekafka"
+	"github.com/segmentio/kafka-go"
+)
+
+// 写入一条随机内容的消息然后验证是否能消费到
+func Test_ProduceAndConsume(t *testing.T) {
+	cmp := ekafka.Load("kafka").Build(
+		ekafka.WithRegisterBalancer("my-balancer", &kafka.Hash{}),
+	)
+
+	randomMessage := RandomString(16)
+	consumed := make(chan struct{}, 1)
+
+	// 写一条随机字符串消息
+	go func() {
+		producer := cmp.Producer("p1")
+		err := producer.WriteMessages(
+			context.Background(),
+			ekafka.Message{Value: []byte(randomMessage)},
+		)
+		if err != nil {
+			panic(err)
+		}
+		if err := producer.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	// 尝试消费 producer 推送的随机字符串消息
+	go func() {
+		ctx, _ := context.WithTimeout(
+			context.Background(),
+			1*time.Minute,
+		)
+		consumer := cmp.Consumer("c1")
+		for {
+			msg, err := consumer.ReadMessage(ctx)
+			if err != nil {
+				panic(err)
+			}
+			received := string(msg.Value)
+			if received == randomMessage {
+				consumed <- struct{}{}
+				if err := consumer.Close(); err != nil {
+					panic(err)
+				}
+				return
+			}
+		}
+	}()
+
+	<-consumed
+}

--- a/ekafka/test/e2e/utils.go
+++ b/ekafka/test/e2e/utils.go
@@ -1,0 +1,17 @@
+package e2e
+
+import (
+	"math/rand"
+	"time"
+)
+
+const charPool = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func RandomString(n int) string {
+	rand.Seed(time.Now().UnixNano())
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = charPool[rand.Intn(len(charPool))]
+	}
+	return string(b)
+}


### PR DESCRIPTION
增加了 E2E 测试，暂时可以在本地启动 Kafka 集群做测试验证，后面有时间可以做到 Actions 里。

增加了 ConsumerGroup 封装，相对于之前的 Consumer 来说，使用更简单，且暴露了 Rebalancing 相关的事件，目前有场景需要用到。示例：

```go
package main

import "github.com/gotomicro/ego-component/ekafka"

func main() {
	cmp := ekafka.Load("kafka").Build()
	// 获取实例（第一次调用时初始化，再次获取时会复用）
	cg := cmp.ConsumerGroup("cg1")

	for {
		pollCtx, _ := context.WithTimeout(ctx, 1*time.Minute)
		// 拉取事件，可能是消息、Rebalancing 事件或者错误等
		event, err := consumerGroup.Poll(pollCtx)
		if err != nil {
			elog.Panic("poll error")
			return
		}
		switch e := event.(type) {
		case ekafka.Message:
			// 按需处理消息
		case ekafka.AssignedPartitions:
			// 在 Kafka 完成分区分配时触发一次
		case ekafka.RevokedPartitions:
			// 在当前 Generation 结束时触发一次
		case error:
			// 错误处理

			// 结束
			if err := cg.Close(); err != nil {
				elog.Panic("关闭ConsumerGroup失败")
			}
		default:
			// ...
		}
	}
}
```