### PR TITLE
support newest wechat API

### DIFF
--- a/ewechat/miniprogram/sns.go
+++ b/ewechat/miniprogram/sns.go
@@ -46,6 +46,11 @@ func (m *MiniProgram) Login(code, encryptedData, iv string) (sessionKey string, 
 		return "", nil, err
 	}
 	wxUserInfo, err = m.Decrypt(wXBizDataCrypt.SessionKey, encryptedData, iv)
+	if err == nil {
+		// 在新版本的微信API里面，将无法从encrypted里面解码出来这两个，而是只能从前面步骤里面拿到
+		wxUserInfo.OpenID = wXBizDataCrypt.OpenID
+		wxUserInfo.UnionID = wXBizDataCrypt.UnionID
+	}
 	sessionKey = wXBizDataCrypt.SessionKey
 	return
 }


### PR DESCRIPTION
根据最新的微信API，无法再继续使用getUserInfo接口。那么换做使用getUserProfile之后，就无法解密出来OpenID，只能依赖于前面一步拿到 OPENID