### PR TITLE
fix invalid xml characters error while posting xml

### DIFF
--- a/ejenkins/examples/_testFiles/job_buildWithDockerfile.xml
+++ b/ejenkins/examples/_testFiles/job_buildWithDockerfile.xml
@@ -1,4 +1,4 @@
-<?xml version='1.1' encoding='UTF-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <flow-definition plugin="workflow-job@2.41">
     <actions>
         <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction

--- a/ejenkins/service_request.go
+++ b/ejenkins/service_request.go
@@ -94,7 +94,7 @@ func (r *Requester) PostXML(endpoint string, payload map[string]string, xml stri
 	if err := r.SetCrumb(ar); err != nil {
 		return nil, err
 	}
-	ar.SetHeader("Content-Type", "application/xml")
+	ar.SetHeader("Content-Type", "text/xml;charset=utf-8")
 	ar.Suffix = ""
 	ar.RequestInst.SetBody(xml)
 	return r.Do(ar, &responseStruct, querystring)


### PR DESCRIPTION
fix error 500 while updating jenkins job by posting config.xml(which contains chinese characters) to jenkins server.
Note, setting encoding="UTF-8" in xml cannot resolve this error. Need to set Content-Type to "text/xml;charset=utf-8" instead of "application/xml".
Also note that, golang can only parse xml 1.0, so, when post xml to jenkins server, please use <?xml version='1.0' ?> in xml, do not use version 1.1, otherwise error will be countered while getting xml content from jenkins server by ejenkins.