### PR TITLE
fix: remove Dialer 10s timeout in consumer group

### DIFF
--- a/ekafka/consumergroup.go
+++ b/ekafka/consumergroup.go
@@ -107,7 +107,6 @@ func NewConsumerGroup(options ConsumerGroupOptions) (*ConsumerGroup, error) {
 
 	if mechanism != nil {
 		dialer := &kafka.Dialer{
-			Timeout:       10 * time.Second,
 			DualStack:     true,
 			SASLMechanism: mechanism,
 		}


### PR DESCRIPTION
去掉consumer group中 dialer默认的10s  timeout