### PR TITLE
feat(ekafka): Add timeout config for ConsumerGroup

### DIFF
--- a/ekafka/README.md
+++ b/ekafka/README.md
@@ -152,6 +152,16 @@ startOffset = "-2"
 #
 # Default: -1
 retentionTime = "-1"
+# Timeout is the network timeout used when communicating with the consumer
+# group coordinator.  This value should not be too small since errors
+# communicating with the broker will generally cause a consumer group
+# rebalance, and it's undesirable that a transient network error intoduce
+# that overhead.  Similarly, it should not be too large or the consumer
+# group may be slow to respond to the coordinator failing over to another
+# broker.
+#
+# Default: 5s
+timeout = "5s"
 # MinBytes indicates to the broker the minimum batch size that the consumer
 # will accept. Setting a high minimum when consuming from a low-volume topic
 # may result in delayed delivery when the broker does not have enough data to

--- a/ekafka/component.go
+++ b/ekafka/component.go
@@ -233,6 +233,7 @@ func (cmp *Component) ConsumerGroup(name string) *ConsumerGroup {
 		JoinGroupBackoff:       config.JoinGroupBackoff,
 		StartOffset:            config.StartOffset,
 		RetentionTime:          config.RetentionTime,
+		Timeout:                config.Timeout,
 		SASLMechanism:          cmp.config.SASLMechanism,
 		SASLUserName:           cmp.config.SASLUserName,
 		SASLPassword:           cmp.config.SASLPassword,

--- a/ekafka/config.go
+++ b/ekafka/config.go
@@ -113,6 +113,7 @@ type consumerGroupConfig struct {
 	JoinGroupBackoff       time.Duration         `json:"joinGroupBackoff" toml:"joinGroupBackoff"`
 	StartOffset            int64                 `json:"startOffset" toml:"startOffset"`
 	RetentionTime          time.Duration         `json:"retentionTime" toml:"retentionTime"`
+	Timeout                time.Duration         `json:"timeout" toml:"timeout"`
 	// Reader otpions:
 	MinBytes        int           `json:"minBytes" toml:"minBytes"`
 	MaxBytes        int           `json:"maxBytes" toml:"maxBytes"`

--- a/ekafka/consumergroup.go
+++ b/ekafka/consumergroup.go
@@ -74,6 +74,7 @@ type ConsumerGroupOptions struct {
 	JoinGroupBackoff       time.Duration
 	StartOffset            int64
 	RetentionTime          time.Duration
+	Timeout                time.Duration
 	Reader                 readerOptions
 	logMode                bool
 	SASLUserName           string
@@ -101,6 +102,7 @@ func NewConsumerGroup(options ConsumerGroupOptions) (*ConsumerGroup, error) {
 		JoinGroupBackoff:       options.JoinGroupBackoff,
 		StartOffset:            options.StartOffset,
 		RetentionTime:          options.RetentionTime,
+		Timeout:                options.Timeout,
 		Logger:                 logger,
 		ErrorLogger:            errorLogger,
 	}


### PR DESCRIPTION
遇到初始化 consumerGroup 时遇到如下错误，看代码是在 kafka-go 对应位置，尝试添加 Timeout 配置修改默认 5s Timeout 时间

```
ekafka@v0.4.2-0.20220729022158-57dd81ba805c/logger.go:20	Unable to establish connection to consumer group coordinator for group some-group-id: read tcp x.x.x.x:21258->x.x.x.x:30372: i/o timeout
```

https://github.com/segmentio/kafka-go/blob/main/consumergroup.go#L786